### PR TITLE
feat: create panzoom and scroll efect for the treemap main page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.0.1"
+        "react-router-dom": "^7.0.1",
+        "react-zoom-pan-pinch": "^3.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -4462,6 +4463,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.6.1.tgz",
+      "integrity": "sha512-SdPqdk7QDSV7u/WulkFOi+cnza8rEZ0XX4ZpeH7vx3UZEg7DoyuAy3MCmm+BWv/idPQL2Oe73VoC0EhfCN+sZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.1"
+    "react-router-dom": "^7.0.1",
+    "react-zoom-pan-pinch": "^3.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,16 @@
 import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import TreemapPage from './pages/TreemapPage.jsx'
 
 function App() {
 
   return (
     <div className='bg-red-500'>
-      <h1>Hooked duo</h1>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/' element={<TreemapPage/>}/>
+        </Routes>
+      </BrowserRouter>
     </div>
   )
 }

--- a/src/pages/TreemapPage.jsx
+++ b/src/pages/TreemapPage.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+
+function TreemapPage
+() {
+
+  const [scale, setScale] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [lastPosition, setLastPosition] = useState({ x: 0, y: 0 });
+
+  const handleWheel = (e) => {
+    e.preventDefault();
+
+    let newScale = scale + e.deltaY * -0.01; 
+    newScale = Math.min(Math.max(0.5, newScale), 3); 
+    setScale(newScale);
+  };
+
+  const handleMouseDown = (e) => {
+    setIsDragging(true);
+    setLastPosition({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMouseMove = (e) => {
+    if (!isDragging) return;
+
+    const deltaX = e.clientX - lastPosition.x;
+    const deltaY = e.clientY - lastPosition.y;
+
+    setPosition((prevPosition) => ({
+      x: prevPosition.x + deltaX,
+      y: prevPosition.y + deltaY,
+    }));
+
+    setLastPosition({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  const handleMouseLeave = () => {
+    setIsDragging(false);
+  };
+
+  return (
+    <div
+      className="flex justify-center items-center h-screen bg-gray-100 overflow-hidden"
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        cursor: isDragging ? 'grabbing' : 'grab',
+        transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+        transformOrigin: 'center center',
+      }}
+    >
+      <div className='flex flex-col gap-10 item'>
+          <h1>Teste</h1>
+      </div>
+    </div>
+  );
+}
+
+export default TreemapPage
+;


### PR DESCRIPTION
### Done
---
- Adds the panzoom effect (drag) using the DOM elements of the div type onMouseDown, onMouseMove and onMouseUp
- Adds the mouse scroll effect with the mouse DOM element onWheel, multiplies it by -0.01 to invert the axis (if scrolling up decreased the deltaY property, now it increases it) and handle high user sensitivity scrolling (default of 100 for most).

![Captura de tela 2024-11-30 151844](https://github.com/user-attachments/assets/a75291d6-d6fa-4ce4-9a6d-a08fff2338bf)
